### PR TITLE
add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "gulp-uglify": "~0.3.0",
     "gulp-watch": "~0.6.5"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-xml-templating/docxtemplater-image-module"
+  },
   "author": "Edgar Hipp",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
when installing using npm, npm complains:

`docxtemplater-image-module@0.3.4 No repository field`