### PR TITLE
gulp-browserify as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gulp": "~3.8.0",
     "gulp-coffee": "~2.0.1",
     "gulp-uglify": "~0.3.0",
+    "gulp-browserify": "^0.5.0",
     "gulp-watch": "~0.6.5"
   },
   "repository": {
@@ -21,7 +22,6 @@
   "license": "MIT",
   "dependencies": {
     "docxtemplater": "^1.0.8",
-    "gulp-browserify": "^0.5.0",
     "jszip": "^2.4.0",
     "png-js": "^0.1.1",
     "qrcode-reader": "0.0.5",


### PR DESCRIPTION
gulp-browserify moved to devDependencies. In this way, npm install --production will not download all browserify packages.